### PR TITLE
Update notifier-stack.ts

### DIFF
--- a/source/src/notifier-stack.ts
+++ b/source/src/notifier-stack.ts
@@ -124,7 +124,6 @@ export class NotifierStack extends cdk.Stack {
       handler: 'lambda_handler',
       runtime: lambda.Runtime.PYTHON_3_8,
       role: notifierFunctionRole,
-      reservedConcurrentExecutions: 100,
       environment: {
         ["CORPID_ARN"]: corpID.value.toString(),
         ["AGENTID_ARN"]: agentID.value.toString(),


### PR DESCRIPTION
delete default reservedConcurrentExecutions: 100

*Issue #, if available:*
An error occurred while deploying.
Because `reservedConcurrentExecutions` is inconsistent with the account default.
<img width="448" alt="image" src="https://user-images.githubusercontent.com/18416040/182528493-0bf8b09a-29b9-4b73-af7d-fd6a01f25c51.png">

*Description of changes:*
delete default reservedConcurrentExecutions: 100

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
